### PR TITLE
Fix the error short-name postgres:17.5-alpine

### DIFF
--- a/chapter02/go/begin/appointments/compose.yml
+++ b/chapter02/go/begin/appointments/compose.yml
@@ -1,6 +1,6 @@
 services:
   db:
-    image: postgres:17.5-alpine
+    image: docker.io/library/postgres:17.5-alpine
     restart: unless-stopped
     ports:
       - 5432:5432

--- a/chapter02/go/end/appointments/compose.yml
+++ b/chapter02/go/end/appointments/compose.yml
@@ -1,6 +1,6 @@
 services:
   db:
-    image: postgres:17.5-alpine
+    image: docker.io/library/postgres:17.5-alpine
     restart: unless-stopped
     ports:
       - 5432:5432

--- a/chapter03/go/begin/appointments/.flox/env/manifest.toml
+++ b/chapter03/go/begin/appointments/.flox/env/manifest.toml
@@ -12,6 +12,7 @@ kubernetes-helm.pkg-path = "kubernetes-helm"
 kustomize.pkg-path = "kustomize"
 pack.pkg-path = "pack"
 skaffold.pkg-path = "skaffold"
+ko.pkg-path = "ko"
 vscode-go-flake.flake = "github:thomasvitale/vscode-go-flake"
 
 [vars]


### PR DESCRIPTION
The container failed to start in chapter02/go/begin and end directories. 

Issues :
1. Error: short-name "postgres:17.5-alpine" did not resolve to an alias and no unqualified-search registries are defined
2. ko was missing in flox manifest

System : 
OS : Ubuntu 22.04.5 LTS
Type : 64-bit

What is fixed:
1. Full image name: docker.io/library/postgres:15-alpine instead of postgres:15-alpine
2. Added ko to flox Manifest